### PR TITLE
Draft PR - Remove (unused) @return_value_parameter & @return_single_parameter

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -199,6 +199,13 @@ module Solargraph
       result
     end
 
+    # @param namespace [String]
+    # @param context [String]
+    # @return [Array<Pin::Namespace>]
+    def get_namespace_pins namespace, context
+      store.fqns_pins(qualify(namespace, context))
+    end
+
     # Get a fully qualified namespace name. This method will start the search
     # in the specified context until it finds a match for the name.
     #

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -147,8 +147,6 @@ module Solargraph
         @pin_select_cache[klass] ||= @pin_class_hash.each_with_object(Set.new) { |(key, o), n| n.merge(o) if key <= klass }
       end
 
-      private
-
       # @param fqns [String]
       # @return [Array<Solargraph::Pin::Namespace>]
       def fqns_pins fqns
@@ -163,6 +161,8 @@ module Solargraph
         end
         fqns_pins_map[[base, name]]
       end
+
+      private
 
       def fqns_pins_map
         @fqns_pins_map ||= Hash.new do |h, (base, name)|

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -110,6 +110,9 @@ module Solargraph
       any?(&:parameterized?)
     end
 
+    # @param definitions [Pin::Namespace]
+    # @param context [Pin::Base]
+    # @return [ComplexType]
     def resolve_parameters definitions, context
       result = @items.map { |i| i.resolve_parameters(definitions, context) }
       ComplexType.parse(*result.map(&:tag))

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -111,10 +111,10 @@ module Solargraph
     end
 
     # @param definitions [Pin::Namespace]
-    # @param context [Pin::Base]
+    # @param context_type [ComplexType]
     # @return [ComplexType]
-    def resolve_parameters definitions, context
-      result = @items.map { |i| i.resolve_parameters(definitions, context) }
+    def resolve_parameters definitions, context_type
+      result = @items.map { |i| i.resolve_parameters(definitions, context_type) }
       ComplexType.parse(*result.map(&:tag))
     end
 

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -59,6 +59,9 @@ module Solargraph
         name == 'param' || all_params.any?(&:parameterized?)
       end
 
+      # @param definitions [Pin::Namespace]
+      # @param context [Pin::Base]
+      # @return [UniqueType]
       def resolve_parameters definitions, context
         new_name = if name == 'param'
           idx = definitions.parameters.index(subtypes.first.name)

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -60,25 +60,25 @@ module Solargraph
       end
 
       # @param definitions [Pin::Namespace]
-      # @param context [Pin::Base]
+      # @param context_type [ComplexType]
       # @return [UniqueType]
-      def resolve_parameters definitions, context
+      def resolve_parameters definitions, context_type
         new_name = if name == 'param'
           idx = definitions.parameters.index(subtypes.first.name)
           return ComplexType::UNDEFINED if idx.nil?
-          param_type = context.return_type.all_params[idx]
+          param_type = context_type.all_params[idx]
           return ComplexType::UNDEFINED unless param_type
           param_type.to_s
         else
           name
         end
         new_key_types = if name != 'param'
-          @key_types.map { |t| t.resolve_parameters(definitions, context) }.select(&:defined?)
+          @key_types.map { |t| t.resolve_parameters(definitions, context_type) }.select(&:defined?)
         else
           []
         end
         new_subtypes = if name != 'param'
-          @subtypes.map { |t| t.resolve_parameters(definitions, context) }.select(&:defined?)
+          @subtypes.map { |t| t.resolve_parameters(definitions, context_type) }.select(&:defined?)
         else
           []
         end

--- a/lib/solargraph/parser.rb
+++ b/lib/solargraph/parser.rb
@@ -19,6 +19,8 @@ module Solargraph
 
     selected = rubyvm? ? Rubyvm : Legacy
     # include selected
+    # @!parse
+    #   extend Solargraph::Parser::Legacy::ClassMethods
     extend selected::ClassMethods
 
     NodeMethods = (rubyvm? ? Rubyvm::NodeMethods : Legacy::NodeMethods)

--- a/lib/solargraph/parser/node_methods.rb
+++ b/lib/solargraph/parser/node_methods.rb
@@ -27,6 +27,7 @@ module Solargraph
         raise NotImplementedError
       end
 
+      # @return [Source::Chain]
       def chain node, filename = nil, in_block = false
         raise NotImplementedError
       end

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -21,6 +21,7 @@ module Solargraph
       # @param parameters [Array<Pin::Parameter>]
       # @param node [Parser::AST::Node, RubyVM::AbstractSyntaxTree::Node]
       # @param attribute [Boolean]
+      # @param signatures [Array<Signature>]
       def initialize visibility: :public, explicit: true, parameters: [], node: nil, attribute: false, signatures: nil, anon_splat: false, **splat
         super(**splat)
         @visibility = visibility
@@ -186,8 +187,37 @@ module Solargraph
         @anon_splat
       end
 
+      # @param arguments_count [Integer]
+      # @return [Array<Pin::Parameter>]
+      def yield_parameters(arguments_count)
+        block_signatures = signatures.select(&:block?).map(&:block)
+        matching_signature = block_signatures.find do |signature|
+          signature.arguments_match?(arguments_count)
+        end
+
+        matching_signature&.parameters || yard_yield_parameters
+      end
+
       private
 
+      # @return [Array<Pin::Parameter]
+      def yard_yield_parameters
+        return [] unless docstring.has_tag?(:yieldparam)
+
+        docstring.tags(:yieldparam).map do |tag|
+          name = tag.name
+          decl = tag.name.nil? ? :arg : :kwarg
+          Pin::Parameter.new(
+            location: location,
+            closure: self,
+            comments: tag.text,
+            name: name,
+            decl: decl,
+            presence: location ? location.range : nil,
+            return_type: ComplexType.try_parse(*tag.types)
+          )
+        end
+      end
 
       # @param tag [YARD::Tags::OverloadTag]
       def param_type_from_name(tag, name)

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -188,27 +188,6 @@ module Solargraph
 
       private
 
-      def select_decl name, asgn
-        if name.start_with?('**')
-          :kwrestarg
-        elsif name.start_with?('*')
-          :restarg
-        elsif name.start_with?('&')
-          :blockarg
-        elsif name.end_with?(':') && asgn
-          :kwoptarg
-        elsif name.end_with?(':')
-          :kwarg
-        elsif asgn
-          :optarg
-        else
-          :arg
-        end
-      end
-
-      def clean_param name
-        name.gsub(/[*&:]/, '')
-      end
 
       # @param tag [YARD::Tags::OverloadTag]
       def param_type_from_name(tag, name)

--- a/lib/solargraph/pin/namespace.rb
+++ b/lib/solargraph/pin/namespace.rb
@@ -14,7 +14,7 @@ module Solargraph
       # @param type [::Symbol] :class or :module
       # @param visibility [::Symbol] :public or :private
       # @param gates [Array<String>]
-      def initialize type: :class, visibility: :public, gates: [''], parameters: [], **splat
+      def initialize type: :class, visibility: :public, gates: [''], parameters: nil, **splat
         # super(location, namespace, name, comments)
         super(**splat)
         @type = type
@@ -88,6 +88,11 @@ module Solargraph
         else
           [path] + @open_gates
         end
+      end
+
+      # @return [Array<String>]
+      def parameters
+        @parameters ||= docstring.tags(:param).map(&:name)
       end
     end
   end

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -123,6 +123,7 @@ module Solargraph
           clip = api_map.clip_at(location.filename, location.range.start)
           locals = clip.locals - [self]
           meths = chain.define(api_map, closure, locals)
+          receiver_type = chain.base.infer(api_map, closure, locals)
           meths.each do |meth|
             if meth.docstring.has_tag?(:yieldparam_single_parameter)
               type = chain.base.infer(api_map, closure, locals)
@@ -133,7 +134,13 @@ module Solargraph
             else
               yps = meth.docstring.tags(:yieldparam)
               unless yps[index].nil? or yps[index].types.nil? or yps[index].types.empty?
-                return ComplexType.try_parse(yps[index].types.first).self_to(chain.base.infer(api_map, closure, locals).namespace).qualify(api_map, meth.context.namespace)
+                yield_type = ComplexType.try_parse(yps[index].types.first)
+                if yield_type.parameterized? && receiver_type.defined?
+                  namespace_pin = api_map.get_namespace_pins(meth.namespace, closure.namespace).first
+                  return yield_type.resolve_parameters(namespace_pin, receiver_type)
+                else
+                  return yield_type.self_to(chain.base.infer(api_map, closure, locals).namespace).qualify(api_map, meth.context.namespace)
+                end
               end
             end
           end

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -125,22 +125,14 @@ module Solargraph
           meths = chain.define(api_map, closure, locals)
           receiver_type = chain.base.infer(api_map, closure, locals)
           meths.each do |meth|
-            if meth.docstring.has_tag?(:yieldparam_single_parameter)
-              type = chain.base.infer(api_map, closure, locals)
-              if type.defined? && !type.subtypes.empty?
-                bmeth = chain.base.define(api_map, closure, locals).first
-                return type.subtypes.first.qualify(api_map, bmeth.context.namespace)
-              end
-            else
-              yps = meth.docstring.tags(:yieldparam)
-              unless yps[index].nil? or yps[index].types.nil? or yps[index].types.empty?
-                yield_type = ComplexType.try_parse(yps[index].types.first)
-                if yield_type.parameterized? && receiver_type.defined?
-                  namespace_pin = api_map.get_namespace_pins(meth.namespace, closure.namespace).first
-                  return yield_type.resolve_parameters(namespace_pin, receiver_type)
-                else
-                  return yield_type.self_to(chain.base.infer(api_map, closure, locals).namespace).qualify(api_map, meth.context.namespace)
-                end
+            yield_param = meth.yield_parameters(closure.parameters.count)[index]
+            unless yield_param.nil? || yield_param.return_type.undefined?
+              yield_type = yield_param.return_type
+              if yield_type.parameterized? && receiver_type.defined?
+                namespace_pin = api_map.get_namespace_pins(meth.namespace, closure.namespace).first
+                return yield_type.resolve_parameters(namespace_pin, receiver_type)
+              else
+                return yield_type.self_to(chain.base.infer(api_map, closure, locals).namespace).qualify(api_map, meth.context.namespace)
               end
             end
           end

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -7,8 +7,12 @@ module Solargraph
       # @return [ComplexType]
       attr_reader :return_type
 
+      # @return [Signature]
       attr_reader :block
 
+      # @param parameters [Array<Parameter>]
+      # @param return_type [ComplexType]
+      # @param block [Signature]
       def initialize parameters, return_type, block = nil
         @parameters = parameters
         @return_type = return_type
@@ -17,6 +21,16 @@ module Solargraph
 
       def block?
         !!@block
+      end
+
+      # @param argcount [Integer]
+      # @return [Boolean]
+      def arguments_match?(argcount, with_block = false)
+        parcount = parameters.length
+        parcount -= 1 if !parameters.empty? && parameters.last.block?
+        return false if block? && !with_block
+        return false if argcount < parcount && !(argcount == parcount - 1 && parameters.last.restarg?)
+        true
       end
     end
   end

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -142,7 +142,8 @@ module Solargraph
           type: :module,
           name: decl.name.relative!.to_s,
           closure: Solargraph::Pin::ROOT_PIN,
-          comments: decl.comment&.string
+          comments: decl.comment&.string,
+          parameters: decl.type_params.map(&:name).map(&:to_s)
         )
         pins.push module_pin
         convert_members_to_pin decl, module_pin

--- a/lib/solargraph/rbs_map/core_fills.rb
+++ b/lib/solargraph/rbs_map/core_fills.rb
@@ -30,20 +30,6 @@ module Solargraph
         )),
       ]
 
-      methods_with_yieldparam_subtypes = %w[
-        Array#each Array#map Array#map! Array#any? Array#all? Array#index
-        Array#keep_if Array#delete_if
-        Enumerable#each_entry Enumerable#map Enumerable#any? Enumerable#all?
-        Enumerable#select Enumerable#reject
-        Set#each
-      ]
-
-      YIELDPARAM_SINGLE_PARAMETERS = methods_with_yieldparam_subtypes.map do |path|
-        Override.from_comment(path, %(
-@yieldparam_single_parameter
-          ))
-      end
-
       CLASS_RETURN_TYPES = [
         Override.method_return('Class#new', 'self'),
         Override.method_return('Class.new', 'Class<BasicObject>'),
@@ -60,7 +46,7 @@ module Solargraph
       end
       ERRNOS = errnos
 
-      ALL = KEYWORDS + MISSING + YIELDPARAMS + YIELDPARAM_SINGLE_PARAMETERS + CLASS_RETURN_TYPES + ERRNOS
+      ALL = KEYWORDS + MISSING + YIELDPARAMS + CLASS_RETURN_TYPES + ERRNOS
     end
   end
 end

--- a/lib/solargraph/rbs_map/core_fills.rb
+++ b/lib/solargraph/rbs_map/core_fills.rb
@@ -20,16 +20,6 @@ module Solargraph
         Solargraph::Pin::Method.new(name: 'class', scope: :instance, closure: Solargraph::Pin::Namespace.new(name: 'Object'), comments: '@return [Class<self>]')
       ]
 
-      YIELDPARAMS = [
-        Override.from_comment('Object#tap', %(
-@return [self]
-@yieldparam [self]
-        )),
-        Override.from_comment('String#each_line', %(
-@yieldparam [String]
-        )),
-      ]
-
       CLASS_RETURN_TYPES = [
         Override.method_return('Class#new', 'self'),
         Override.method_return('Class.new', 'Class<BasicObject>'),
@@ -46,7 +36,7 @@ module Solargraph
       end
       ERRNOS = errnos
 
-      ALL = KEYWORDS + MISSING + YIELDPARAMS + CLASS_RETURN_TYPES + ERRNOS
+      ALL = KEYWORDS + MISSING + CLASS_RETURN_TYPES + ERRNOS
     end
   end
 end

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -128,7 +128,7 @@ module Solargraph
           @@inference_stack.pop
           if type.defined?
             if type.parameterized?
-              type = type.resolve_parameters(pin.closure, context)
+              type = type.resolve_parameters(pin.closure, context.return_type)
               # idx = pin.closure.parameters.index(type.subtypes.first.name)
               # next if idx.nil?
               # param_type = context.return_type.all_params[idx]

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -57,7 +57,7 @@ module Solargraph
             # next p if overloads.empty?
             type = ComplexType::UNDEFINED
             overloads.each do |ol|
-              next unless arguments_match(arguments, ol)
+              next unless ol.arguments_match?(arguments.length, with_block?)
               # next if ol.parameters.last && ol.parameters.last.first.start_with?('&') && ol.parameters.last.last.nil? && !with_block?
               match = true
               arguments.each_with_index do |arg, idx|
@@ -180,19 +180,6 @@ module Solargraph
             return context.value_types.first
           end
           nil
-        end
-
-        # @param arguments [Array<Chain>]
-        # @param signature [Pin::Signature]
-        # @return [Boolean]
-        def arguments_match arguments, signature
-          parameters = signature.parameters
-          argcount = arguments.length
-          parcount = parameters.length
-          parcount -= 1 if !parameters.empty? && parameters.last.block?
-          return false if signature.block? && !with_block?
-          return false if argcount < parcount && !(argcount == parcount - 1 && parameters.last.restarg?)
-          true
         end
 
         # @param api_map [ApiMap]

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -176,8 +176,6 @@ module Solargraph
         def extra_return_type docstring, context
           if docstring.has_tag?(:return_single_parameter) #&& context.subtypes.one?
             return context.subtypes.first || ComplexType::UNDEFINED
-          elsif docstring.has_tag?(:return_value_parameter) && context.value_types.one?
-            return context.value_types.first
           end
           nil
         end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -75,27 +75,12 @@ module Solargraph
                 end
               end
               if match
-                type = extra_return_type(p.docstring, context)
-                break if type
                 type = with_params(ol.return_type.self_to(context.to_s), context).qualify(api_map, context.namespace) if ol.return_type.defined?
                 type ||= ComplexType::UNDEFINED
               end
               break if type.defined?
             end
             next p.proxy(type) if type.defined?
-            type = extra_return_type(p.docstring, context)
-            if type
-              next Solargraph::Pin::Method.new(
-                location: p.location,
-                closure: p.closure,
-                name: p.name,
-                comments: "@return [#{context.subtypes.first.to_s}]",
-                scope: p.scope,
-                visibility: p.visibility,
-                parameters: p.parameters,
-                node: p.node
-              )
-            end
             if p.is_a?(Pin::Method) && !p.macros.empty?
               result = process_macro(p, api_map, context, locals)
               next result unless result.return_type.undefined?
@@ -168,16 +153,6 @@ module Solargraph
             return Pin::ProxyType.anonymous(ComplexType.try_parse(*tag.types))
           end
           Pin::ProxyType.anonymous(ComplexType::UNDEFINED)
-        end
-
-        # @param docstring [YARD::Docstring]
-        # @param context [ComplexType]
-        # @return [ComplexType]
-        def extra_return_type docstring, context
-          if docstring.has_tag?(:return_single_parameter) #&& context.subtypes.one?
-            return context.subtypes.first || ComplexType::UNDEFINED
-          end
-          nil
         end
 
         # @param api_map [ApiMap]

--- a/lib/yard-solargraph.rb
+++ b/lib/yard-solargraph.rb
@@ -19,8 +19,6 @@ YARD::Tags::Library.define_tag("Type", :type, :with_types_and_name)
 YARD::Tags::Library.define_tag("Yieldself", :yieldself, :with_types)
 # Define a @yieldpublic tag for documenting block domains
 YARD::Tags::Library.define_tag("Yieldpublic", :yieldpublic, :with_types)
-# Define a @return_single_parameter tag for returning e.g. Array parameters
-YARD::Tags::Library.define_tag('ReturnSingleParameter', :return_single_parameter)
 # Define a @param_tuple tag for e.g. Hash#[]= parameters
 YARD::Tags::Library.define_tag('ParamTuple', :param_tuple)
 # Define a @!domain directive for documenting DSLs

--- a/lib/yard-solargraph.rb
+++ b/lib/yard-solargraph.rb
@@ -21,8 +21,6 @@ YARD::Tags::Library.define_tag("Yieldself", :yieldself, :with_types)
 YARD::Tags::Library.define_tag("Yieldpublic", :yieldpublic, :with_types)
 # Define a @return_single_parameter tag for returning e.g. Array parameters
 YARD::Tags::Library.define_tag('ReturnSingleParameter', :return_single_parameter)
-# Define a @yieldparam_single_parameter tag for yielding e.g. Array parameters
-YARD::Tags::Library.define_tag('YieldparamSingleParameter', :yieldparam_single_parameter)
 # Define a @return_value_parameter tag for returning e.g. Hash values
 YARD::Tags::Library.define_tag('ReturnValueParameter', :return_value_parameter)
 # Define a @param_tuple tag for e.g. Hash#[]= parameters

--- a/lib/yard-solargraph.rb
+++ b/lib/yard-solargraph.rb
@@ -21,8 +21,6 @@ YARD::Tags::Library.define_tag("Yieldself", :yieldself, :with_types)
 YARD::Tags::Library.define_tag("Yieldpublic", :yieldpublic, :with_types)
 # Define a @return_single_parameter tag for returning e.g. Array parameters
 YARD::Tags::Library.define_tag('ReturnSingleParameter', :return_single_parameter)
-# Define a @return_value_parameter tag for returning e.g. Hash values
-YARD::Tags::Library.define_tag('ReturnValueParameter', :return_value_parameter)
 # Define a @param_tuple tag for e.g. Hash#[]= parameters
 YARD::Tags::Library.define_tag('ParamTuple', :param_tuple)
 # Define a @!domain directive for documenting DSLs

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -297,7 +297,7 @@ describe Solargraph::ComplexType do
       name: 'bar',
       comments: '@return [Foo<String>]'
     )
-    type = return_type.resolve_parameters(generic_class, called_method)
+    type = return_type.resolve_parameters(generic_class, called_method.return_type)
     expect(type.tag).to eq('Array<String>')
   end
 end

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -286,4 +286,18 @@ describe Solargraph::ComplexType do
     result = type.qualify(api_map)
     expect(result.tag).to eq('String')
   end
+
+  it 'resolves generic parameters' do
+    api_map = Solargraph::ApiMap.new
+    return_type = Solargraph::ComplexType.parse('Array<param<GenericTypeParam>>')
+    generic_class = Solargraph::Pin::Namespace.new(name: 'Foo', comments: '@param GenericTypeParam')
+    called_method = Solargraph::Pin::Method.new(
+      location: Solargraph::Location.new('file:///foo.rb', Solargraph::Range.from_to(0, 0, 0, 0)),
+      closure: generic_class,
+      name: 'bar',
+      comments: '@return [Foo<String>]'
+    )
+    type = return_type.resolve_parameters(generic_class, called_method)
+    expect(type.tag).to eq('Array<String>')
+  end
 end

--- a/spec/pin/namespace_spec.rb
+++ b/spec/pin/namespace_spec.rb
@@ -26,4 +26,9 @@ describe Solargraph::Pin::Namespace do
     expect(pin.name).to eq('Baz')
     expect(pin.path).to eq('Foo::Bar::Baz')
   end
+
+  it 'uses @param tags as generic type parameters' do
+    pin = Solargraph::Pin::Namespace.new(name: 'Foo', comments: '@param GenericType')
+    expect(pin.parameters).to eq(['GenericType'])
+  end
 end

--- a/spec/pin/parameter_spec.rb
+++ b/spec/pin/parameter_spec.rb
@@ -270,9 +270,7 @@ describe Solargraph::Pin::Parameter do
     expect(pin.documentation).not_to include('The bar method')
   end
 
-  it "typifies from yieldparam_single_parameter" do
-    # This test depends on the fact that Array#each has a
-    # yieldparam_single_parameter tag.
+  it "typifies from RBS generic yield params" do
     source = Solargraph::Source.load_string(%(
       # @return [Array<String>]
       def list_strings; end
@@ -282,7 +280,7 @@ describe Solargraph::Pin::Parameter do
       def use_string str
         while x
           list = list_strings
-          list.each do |s|
+          list.each_with_index do |s, _index|
             use_string(s)
           end
         end


### PR DESCRIPTION
Relates to: https://github.com/castwide/solargraph/pull/743

>  Deprecate @return_single_parameter and @yieldparam_single_parameter(?)