### PR TITLE
Add branch name to output dir

### DIFF
--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -241,6 +241,100 @@ module Solargraph
       puts "#{workspace.filenames.length} files total."
     end
 
+    desc 'profile [FILE]', 'Profile go-to-definition performance using vernier'
+    option :directory, type: :string, aliases: :d, desc: 'The workspace directory', default: '.'
+    option :output_dir, type: :string, aliases: :o, desc: 'The output directory for profiles', default: './tmp/profiles'
+    option :line, type: :numeric, aliases: :l, desc: 'Line number (0-based)', default: 4
+    option :column, type: :numeric, aliases: :c, desc: 'Column number', default: 10
+    # @param file [String, nil]
+    # @return [void]
+    def profile(file = nil) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      begin
+        require 'vernier'
+      rescue LoadError
+        STDERR.puts "vernier gem not found. Install with: gem install vernier"
+        return
+      end
+
+      directory = File.realpath(options[:directory])
+      FileUtils.mkdir_p(options[:output_dir])
+
+      host = Solargraph::LanguageServer::Host.new
+      host.client_capabilities.merge!({ 'window' => { 'workDoneProgress' => true } })
+      def host.send_notification method, params
+        puts "Notification: #{method} - #{params}"
+      end
+
+      puts "Parsing and mapping source files..."
+      prepare_start = Time.now
+      Vernier.profile(out: "#{options[:output_dir]}/parse_benchmark.json.gz") do
+        puts "Mapping libraries"
+        host.prepare(directory)
+        sleep 0.2 until host.libraries.all?(&:mapped?)
+      end
+      prepare_time = Time.now - prepare_start
+
+      puts "Building the catalog..."
+      catalog_start = Time.now
+      Vernier.profile(out: "#{options[:output_dir]}/catalog_benchmark.json.gz") do
+        host.catalog
+      end
+      catalog_time = Time.now - catalog_start
+
+      # Determine test file
+      if file
+        test_file = File.join(directory, file)
+      else
+        test_file = File.join(directory, 'lib', 'other.rb')
+        unless File.exist?(test_file)
+          # Fallback to any Ruby file in the workspace
+          workspace = Solargraph::Workspace.new(directory)
+          test_file = workspace.filenames.find { |f| f.end_with?('.rb') }
+          unless test_file
+            STDERR.puts "No Ruby files found in workspace"
+            return
+          end
+        end
+      end
+
+      file_uri = Solargraph::LanguageServer::UriHelpers.file_to_uri(File.absolute_path(test_file))
+
+      puts "Profiling go-to-definition for #{test_file}"
+      puts "Position: line #{options[:line]}, column #{options[:column]}"
+
+      definition_start = Time.now
+      Vernier.profile(out: "#{options[:output_dir]}/definition_benchmark.json.gz") do
+        message = Solargraph::LanguageServer::Message::TextDocument::Definition.new(
+          host, {
+            'params' => {
+              'textDocument' => { 'uri' => file_uri },
+              'position' => { 'line' => options[:line], 'character' => options[:column] }
+            }
+          }
+        )
+        puts "Processing go-to-definition request..."
+        result = message.process
+
+        puts "Result: #{result.inspect}"
+      end
+      definition_time = Time.now - definition_start
+
+      puts "\n=== Timing Results ==="
+      puts "Parsing & mapping: #{(prepare_time * 1000).round(2)}ms"
+      puts "Catalog building: #{(catalog_time * 1000).round(2)}ms"
+      puts "Go-to-definition: #{(definition_time * 1000).round(2)}ms"
+      total_time = prepare_time + catalog_time + definition_time
+      puts "Total time: #{(total_time * 1000).round(2)}ms"
+
+      puts "\nProfiles saved to:"
+      puts "  - #{File.expand_path('parse_benchmark.json.gz', options[:output_dir])}"
+      puts "  - #{File.expand_path('catalog_benchmark.json.gz', options[:output_dir])}"
+      puts "  - #{File.expand_path('definition_benchmark.json.gz', options[:output_dir])}"
+
+      puts "\nUpload the JSON files to https://vernier.prof/ to view the profiles."
+      puts "Or use https://rubygems.org/gems/profile-viewer to view them locally."
+    end
+
     private
 
     # @param pin [Solargraph::Pin::Base]

--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -261,7 +261,10 @@ module Solargraph
       hooks << :memory_usage if options[:memory]
 
       directory = File.realpath(options[:directory])
-      FileUtils.mkdir_p(options[:output_dir])
+
+      branch_name = `git rev-parse --abbrev-ref HEAD`.strip
+      output_dir = File.join(options[:output_dir], branch_name)
+      FileUtils.mkdir_p(output_dir)
 
       host = Solargraph::LanguageServer::Host.new
       host.client_capabilities.merge!({ 'window' => { 'workDoneProgress' => true } })
@@ -271,7 +274,7 @@ module Solargraph
 
       puts "Parsing and mapping source files..."
       prepare_start = Time.now
-      Vernier.profile(out: "#{options[:output_dir]}/parse_benchmark.json.gz", hooks: hooks) do
+      Vernier.profile(out: "#{output_dir}/parse_benchmark.json.gz", hooks: hooks) do
         puts "Mapping libraries"
         host.prepare(directory)
         sleep 0.2 until host.libraries.all?(&:mapped?)
@@ -280,7 +283,7 @@ module Solargraph
 
       puts "Building the catalog..."
       catalog_start = Time.now
-      Vernier.profile(out: "#{options[:output_dir]}/catalog_benchmark.json.gz", hooks: hooks) do
+      Vernier.profile(out: "#{output_dir}/catalog_benchmark.json.gz", hooks: hooks) do
         host.catalog
       end
       catalog_time = Time.now - catalog_start
@@ -307,7 +310,7 @@ module Solargraph
       puts "Position: line #{options[:line]}, column #{options[:column]}"
 
       definition_start = Time.now
-      Vernier.profile(out: "#{options[:output_dir]}/definition_benchmark.json.gz", hooks: hooks) do
+      Vernier.profile(out: "#{output_dir}/definition_benchmark.json.gz", hooks: hooks) do
         message = Solargraph::LanguageServer::Message::TextDocument::Definition.new(
           host, {
             'params' => {
@@ -331,9 +334,9 @@ module Solargraph
       puts "Total time: #{(total_time * 1000).round(2)}ms"
 
       puts "\nProfiles saved to:"
-      puts "  - #{File.expand_path('parse_benchmark.json.gz', options[:output_dir])}"
-      puts "  - #{File.expand_path('catalog_benchmark.json.gz', options[:output_dir])}"
-      puts "  - #{File.expand_path('definition_benchmark.json.gz', options[:output_dir])}"
+      puts "  - #{File.expand_path('parse_benchmark.json.gz', output_dir)}"
+      puts "  - #{File.expand_path('catalog_benchmark.json.gz', output_dir)}"
+      puts "  - #{File.expand_path('definition_benchmark.json.gz', output_dir)}"
 
       puts "\nUpload the JSON files to https://vernier.prof/ to view the profiles."
       puts "Or use https://rubygems.org/gems/profile-viewer to view them locally."

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -59,6 +59,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'undercover', '~> 0.7'
   s.add_development_dependency 'overcommit', '~> 0.68.0'
   s.add_development_dependency 'webmock', '~> 3.6'
+  s.add_development_dependency 'vernier'
   # work around missing yard dependency needed as of Ruby 3.5
   s.add_development_dependency 'irb', '~> 1.15'
 end


### PR DESCRIPTION
This made 'solargraph profile' a lot easier to use - I didn't need to specify anything while comparing the results from multiple branches.